### PR TITLE
Telecomm: Set MSIM audio params using the proper ID

### DIFF
--- a/src/com/android/server/telecom/CallsManager.java
+++ b/src/com/android/server/telecom/CallsManager.java
@@ -322,7 +322,8 @@ public class CallsManager extends Call.ListenerBase
 
         mCallAudioManager = new CallAudioManager(callAudioRouteStateMachine,
                 this,new CallAudioModeStateMachine((AudioManager)
-                        mContext.getSystemService(Context.AUDIO_SERVICE)),
+                        mContext.getSystemService(Context.AUDIO_SERVICE),
+                        (TelecomManager) mContext.getSystemService(Context.TELECOM_SERVICE)),
                 playerFactory, mRinger, new RingbackPlayer(playerFactory), mDtmfLocalTonePlayer);
 
         mHeadsetMediaButton = headsetMediaButtonFactory.create(context, this, mLock);


### PR DESCRIPTION
It is assumed that the ID of every PhoneAccountHandle is the string
equivalent of an int, however, the ID can also includes hex chars or,
in case of the emergency account handle, it's just "E". This causes
issues when we try to get the sub ID using Integer.parseInt(),
so don't do it.

Change-Id: Iae6cfacaf65bb2791b6fa9ae491bb4ad6edbe936